### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An unofficial Model Context Protocol (MCP) server for accessing Fathom Analytics data through an AI assistant. This implementation uses the [@mackenly/fathom-api](https://github.com/mackenly/fathom-api) unofficial SDK to interact with the Fathom Analytics API. Not affiliated, endorsed, or supported by Fathom Analytics.
 
+<a href="https://glama.ai/mcp/servers/56cxbakbc4">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/56cxbakbc4/badge" alt="Fathom Analytics MCP server" />
+</a>
+
 ## Features
 
 The MCP server provides the following Fathom Analytics tools:


### PR DESCRIPTION
This PR adds a badge for the [MCP Fathom Analytics](https://glama.ai/mcp/servers/56cxbakbc4) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/56cxbakbc4">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/56cxbakbc4/badge" alt="Fathom Analytics MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.